### PR TITLE
Use pip for `build_host_setup.sh.

### DIFF
--- a/build_host_setup.sh
+++ b/build_host_setup.sh
@@ -4,6 +4,7 @@ sudo apt-get install -y \
     git \
     python \
     python-dev \
+    python-pip \
     python-setuptools \
     python-virtualenv \
     python-gobject-dev \
@@ -22,4 +23,4 @@ sudo apt-get install -y \
     curl
 
 # upgrade virtualenv to latest from pypi
-sudo easy_install --upgrade virtualenv
+sudo pip install --upgrade virtualenv


### PR DESCRIPTION
Running an up to date Ubuntu MATE 16.04 workstation, with other Python development tools installed, I was unable to complete `build_host_setup.sh` due to version conflict with `setuptools`. 

This pull request replace `easy_setup` with `pip` to complete the upgrade of `virtualenv`.